### PR TITLE
feat: use sub instead of id to check admin rights

### DIFF
--- a/db/migrations/20250604.sql
+++ b/db/migrations/20250604.sql
@@ -5,8 +5,4 @@ BEGIN;
 ALTER TABLE :schema_name.users
 RENAME COLUMN is_email_confirmed TO is_verified;
 
-ALTER TABLE :schema_name.users
-ADD CONSTRAINT users_sub_pro_connect_unique UNIQUE (sub_pro_connect)
-WHERE sub_pro_connect IS NOT NULL;
-
 COMMIT;

--- a/db/migrations/20250604.sql
+++ b/db/migrations/20250604.sql
@@ -5,4 +5,8 @@ BEGIN;
 ALTER TABLE :schema_name.users
 RENAME COLUMN is_email_confirmed TO is_verified;
 
+ALTER TABLE :schema_name.users
+ADD CONSTRAINT users_sub_pro_connect_unique UNIQUE (sub_pro_connect)
+WHERE sub_pro_connect IS NOT NULL;
+
 COMMIT;

--- a/db/migrations/20250604.sql
+++ b/db/migrations/20250604.sql
@@ -1,0 +1,8 @@
+\set schema_name :DB_SCHEMA
+
+BEGIN;
+
+ALTER TABLE :schema_name.users
+RENAME COLUMN is_email_confirmed TO is_verified;
+
+COMMIT;

--- a/db/migrations/20250605.sql
+++ b/db/migrations/20250605.sql
@@ -1,0 +1,9 @@
+\set schema_name :DB_SCHEMA
+
+BEGIN;
+
+CREATE UNIQUE INDEX users_sub_pro_connect_unique_idx
+ON :schema_name.users (sub_pro_connect)
+WHERE sub_pro_connect IS NOT NULL;
+
+COMMIT;

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -14,7 +14,7 @@ INSERT INTO :schema_name.groups (id, name, orga_id)
 VALUES (1, 'stack technique', 1) ON CONFLICT (id) DO NOTHING;
 
 -- Create users with different emails
-INSERT INTO :schema_name.users (id, email, is_email_confirmed)
+INSERT INTO :schema_name.users (id, email, is_verified)
 VALUES
   (1, 'user@yopmail.com', false),
   (2, 'xavier.jouppe@beta.gouv.fr', false),

--- a/src/model.py
+++ b/src/model.py
@@ -1,27 +1,51 @@
-from typing import Annotated, NewType
+from typing import Annotated
 from xmlrpc.client import boolean
 
-from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
-
-# Create a NewType for type hints
-Siren = NewType("Siren", str)
+from fastapi import HTTPException, status
+from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr, Field
 
 
-# Validator function
 def validate_siren(v: str) -> str:
     if not isinstance(v, str) or not v.isdigit() or len(v) != 9:
-        raise ValueError("Siren must be a 9-digit string")
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, "Siren must be a 9-digit string"
+        )
+
+    if v == "356000000":
+        # La poste
+        return v
+
+    # Luhn algorithm
+    total = 0
+    for i, char in enumerate(reversed(v)):
+        digit = int(char)
+        if i % 2 == 1:  # Every second digit from right
+            digit *= 2
+            if digit > 9:
+                digit = digit // 10 + digit % 10
+        total += digit
+
+    if total % 10 != 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid SIREN: fails Luhn checksum",
+        )
+
     return v
 
 
 # Type annotation with validation
-SirenType = Annotated[str, field_validator("validate_siren")]
+Siren = Annotated[
+    str,
+    BeforeValidator(validate_siren),
+    Field(description="A valid Siren"),
+]
 
 
 # --- Organisation ---
 class OrganisationBase(BaseModel):
     name: str | None = None
-    siren: Siren  # type: ignore # Optional for group creation
+    siren: Siren
 
 
 class OrganisationCreate(OrganisationBase):

--- a/src/models.py
+++ b/src/models.py
@@ -47,10 +47,9 @@ class UserCreate(UserBase):
     pass
 
 
-class UserResponse(UserBase):
+class UserResponse(BaseModel):
     id: int
-
-    model_config = ConfigDict(from_attributes=True)
+    email: EmailStr
 
 
 class UserWithRoleResponse(UserBase):

--- a/src/models.py
+++ b/src/models.py
@@ -39,17 +39,17 @@ class OrganisationResponse(OrganisationBase):
 
 class UserBase(BaseModel):
     email: EmailStr
-    sub_pro_connect: str | None = None
-    is_email_confirmed: bool = False
 
 
 class UserCreate(UserBase):
     pass
 
 
-class UserResponse(BaseModel):
+class UserResponse(UserBase):
     id: int
-    email: EmailStr
+    is_verified: bool
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserWithRoleResponse(UserBase):

--- a/src/repositories/auth.py
+++ b/src/repositories/auth.py
@@ -1,7 +1,7 @@
 # ------- REPOSITORY FILE -------
 
 
-from src.models import ServiceAccountResponse
+from src.model import ServiceAccountResponse
 
 
 class AuthRepository:

--- a/src/repositories/groups.py
+++ b/src/repositories/groups.py
@@ -1,5 +1,5 @@
 # ------- REPOSITORY FILE -------
-from ..models import GroupCreate, GroupResponse, GroupWithUsersAndScopesResponse
+from ..model import GroupCreate, GroupResponse, GroupWithUsersAndScopesResponse
 
 
 class GroupsRepository:

--- a/src/repositories/organisations.py
+++ b/src/repositories/organisations.py
@@ -1,5 +1,5 @@
 # ------- REPOSITORY FILE -------
-from ..models import OrganisationCreate, OrganisationResponse
+from ..model import OrganisationCreate, OrganisationResponse
 
 
 class OrganisationsRepository:

--- a/src/repositories/roles.py
+++ b/src/repositories/roles.py
@@ -1,5 +1,5 @@
 # ------- REPOSITORY FILE -------
-from ..models import RoleResponse
+from ..model import RoleResponse
 
 
 class RolesRepository:

--- a/src/repositories/scopes.py
+++ b/src/repositories/scopes.py
@@ -1,5 +1,5 @@
 # ------- REPOSITORY FILE -------
-from src.models import ScopeResponse
+from src.model import ScopeResponse
 
 
 class ScopesRepository:

--- a/src/repositories/service_providers.py
+++ b/src/repositories/service_providers.py
@@ -1,4 +1,4 @@
-from src.models import ServiceProviderResponse
+from src.model import ServiceProviderResponse
 
 
 class ServiceProvidersRepository:

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -9,7 +9,7 @@ class UsersRepository:
     async def verify_user(self, user_email: str, user_sub: str):
         async with self.db_session.transaction():
             query = """
-            UPDATE users SET sub_pro_connect = :sub_pro_connect, is_email_confirmed = TRUE
+            UPDATE users SET sub_pro_connect = :sub_pro_connect, is_verified = TRUE
             WHERE email = :email
             """
             values = {"email": user_email, "sub_pro_connect": user_sub}
@@ -18,28 +18,28 @@ class UsersRepository:
     async def get_user_by_email(self, email: str) -> UserResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT U.id, U.email FROM users as U WHERE U.email = :email
+            SELECT U.id, U.email, U.is_verified FROM users as U WHERE U.email = :email
             """
             return await self.db_session.fetch_one(query, {"email": email})
 
     async def get_user_by_id(self, user_id: int) -> UserResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT U.id, U.email FROM users as U WHERE U.id = :id
+            SELECT U.id, U.email, U.is_verified FROM users as U WHERE U.id = :id
             """
             return await self.db_session.fetch_one(query, {"id": user_id})
 
     async def get_user_by_sub(self, user_sub: str) -> UserResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT U.id, U.email FROM users as U WHERE U.sub_pro_connect = :sub_pro_connect
+            SELECT U.id, U.email, U.is_verified FROM users as U WHERE U.sub_pro_connect = :sub_pro_connect
             """
             return await self.db_session.fetch_one(query, {"sub_pro_connect": user_sub})
 
     async def get_users_by_group_id(self, group_id: int) -> list[UserWithRoleResponse]:
         async with self.db_session.transaction():
             query = """
-                SELECT U.id, U.email, U.created_at, R.role_name, R.is_admin
+                SELECT U.id, U.email, U.is_verified, U.created_at, R.role_name, R.is_admin
                 FROM users as U
                 INNER JOIN group_user_relations as TUR ON TUR.user_id = U.id
                 INNER JOIN roles as R ON TUR.role_id = R.id
@@ -49,6 +49,6 @@ class UsersRepository:
 
     async def add_user(self, user: UserCreate) -> UserResponse:
         async with self.db_session.transaction():
-            query = "INSERT INTO users (email, is_email_confirmed) VALUES (:email, :is_email_confirmed) RETURNING *"
-            values = {"email": user.email, "is_email_confirmed": False}
+            query = "INSERT INTO users (email, is_verified) VALUES (:email, :is_verified) RETURNING *"
+            values = {"email": user.email, "is_verified": False}
             return await self.db_session.fetch_one(query, values)

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -9,21 +9,28 @@ class UsersRepository:
     async def get_user_by_email(self, email: str) -> UserResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT * FROM users as U WHERE U.email = :email
+            SELECT U.id, U.email FROM users as U WHERE U.email = :email
             """
             return await self.db_session.fetch_one(query, {"email": email})
 
     async def get_user_by_id(self, user_id: int) -> UserResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT * FROM users as U WHERE U.id = :id
+            SELECT U.id, U.email FROM users as U WHERE U.id = :id
             """
             return await self.db_session.fetch_one(query, {"id": user_id})
+
+    async def get_user_by_sub(self, user_sub: str) -> UserResponse:
+        async with self.db_session.transaction():
+            query = """
+            SELECT U.id, U.email FROM users as U WHERE U.sub_pro_connect = :sub_pro_connect
+            """
+            return await self.db_session.fetch_one(query, {"sub_pro_connect": user_sub})
 
     async def get_users_by_group_id(self, group_id: int) -> list[UserWithRoleResponse]:
         async with self.db_session.transaction():
             query = """
-                SELECT U.id, U.email, U.sub_pro_connect, U.created_at, R.role_name, R.is_admin
+                SELECT U.id, U.email, U.created_at, R.role_name, R.is_admin
                 FROM users as U
                 INNER JOIN group_user_relations as TUR ON TUR.user_id = U.id
                 INNER JOIN roles as R ON TUR.role_id = R.id

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -1,12 +1,14 @@
 # ------- REPOSITORY FILE -------
-from ..models import UserCreate, UserResponse, UserWithRoleResponse
+from pydantic import UUID4
+
+from ..model import UserCreate, UserResponse, UserWithRoleResponse
 
 
 class UsersRepository:
     def __init__(self, db_session):
         self.db_session = db_session
 
-    async def verify_user(self, user_email: str, user_sub: str):
+    async def verify_user(self, user_email: str, user_sub: UUID4):
         async with self.db_session.transaction():
             query = """
             UPDATE users SET sub_pro_connect = :sub_pro_connect, is_verified = TRUE
@@ -29,12 +31,14 @@ class UsersRepository:
             """
             return await self.db_session.fetch_one(query, {"id": user_id})
 
-    async def get_user_by_sub(self, user_sub: str) -> UserResponse:
+    async def get_user_by_sub(self, user_sub: UUID4) -> UserResponse:
         async with self.db_session.transaction():
             query = """
             SELECT U.id, U.email, U.is_verified FROM users as U WHERE U.sub_pro_connect = :sub_pro_connect
             """
-            return await self.db_session.fetch_one(query, {"sub_pro_connect": user_sub})
+            return await self.db_session.fetch_one(
+                query, {"sub_pro_connect": str(user_sub)}
+            )
 
     async def get_users_by_group_id(self, group_id: int) -> list[UserWithRoleResponse]:
         async with self.db_session.transaction():

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -6,6 +6,15 @@ class UsersRepository:
     def __init__(self, db_session):
         self.db_session = db_session
 
+    async def verify_user(self, user_email: str, user_sub: str):
+        async with self.db_session.transaction():
+            query = """
+            UPDATE users SET sub_pro_connect = :sub_pro_connect, is_email_confirmed = TRUE
+            WHERE email = :email
+            """
+            values = {"email": user_email, "sub_pro_connect": user_sub}
+            await self.db_session.execute(query, values)
+
     async def get_user_by_email(self, email: str) -> UserResponse:
         async with self.db_session.transaction():
             query = """

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPBasic
 
 from src.auth import ACCESS_TOKEN_EXPIRE_MINUTES, create_access_token
 from src.dependencies import get_auth_service
-from src.models import Token
+from src.model import Token
 from src.services.auth import AuthService
 
 router = APIRouter(

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -25,13 +25,13 @@ async def get_token(
     auth_service: AuthService = Depends(get_auth_service),
 ):
     """
-    OAuth2 token endpoint for Client Credentials flow.
+    OAuth2 pour un flow “Client Credentials”.
 
-    Client authentication can be provided through:
-    1. HTTP Basic Authentication in the Authorization header
-    2. Request body with client_id and client_secret fields
+    L’authentication peut être effectuée de deux manières :
+    1. HTTP Basic Authentication dans le header Authorization
+    2. `client_id` et `client_secret` dans le body de la requête (form data)
 
-    The grant_type must be 'client_credentials'.
+    Le `grant_type` est `client_credentials`.
     """
     # Verify grant type
     if grant_type != "client_credentials":

--- a/src/routers/groups.py
+++ b/src/routers/groups.py
@@ -30,8 +30,8 @@ async def list_groups(
 @router.get("/search", response_model=list[GroupWithUsersAndScopesResponse])
 async def search(
     email: EmailStr = Query(..., description="Mail de l’utilisateur"),
-    active_user_sub: str | None = Query(
-        ..., description="Sub de l’utilisateur (facultatif)"
+    acting_user_sub: str | None = Query(
+        None, description="Sub de l’utilisateur (facultatif)"
     ),
     users_service: UsersService = Depends(get_users_service),
     group_service: GroupsService = Depends(get_groups_service),
@@ -41,10 +41,11 @@ async def search(
 
     Si l'utilisateur n'est pas encore vérifié, l’appel échouera et vous devrez vérifier l'utilisateur (cf. `/users/verify`).
 
-    Il est possible de passer en argument `active_user_sub` qui permet de se passer d’un appel à `/user/verify`
+    Il est possible de passer en argument `acting_user_sub` qui permet de se passer d’un appel à `/user/verify`
     """
-    if active_user_sub:
-        await users_service.verify_user(user_sub=active_user_sub, user_email=email)
+
+    if acting_user_sub:
+        await users_service.verify_user(user_sub=acting_user_sub, user_email=email)
 
     return await group_service.search_groups(email=email)
 

--- a/src/routers/groups.py
+++ b/src/routers/groups.py
@@ -1,12 +1,12 @@
 # ------- USER ROUTER FILE -------
 from fastapi import APIRouter, Depends, Path, Query
-from pydantic import EmailStr
+from pydantic import UUID4, EmailStr
 
 from src.auth import decode_access_token
 from src.dependencies import get_groups_service, get_users_service
 from src.services.users import UsersService
 
-from ..models import GroupCreate, GroupResponse, GroupWithUsersAndScopesResponse
+from ..model import GroupCreate, GroupResponse, GroupWithUsersAndScopesResponse
 from ..services.groups import GroupsService
 
 router = APIRouter(
@@ -30,7 +30,7 @@ async def list_groups(
 @router.get("/search", response_model=list[GroupWithUsersAndScopesResponse])
 async def search(
     email: EmailStr = Query(..., description="Mail de l’utilisateur"),
-    acting_user_sub: str | None = Query(
+    acting_user_sub: UUID4 | None = Query(
         None, description="Sub de l’utilisateur (facultatif)"
     ),
     users_service: UsersService = Depends(get_users_service),

--- a/src/routers/groups.py
+++ b/src/routers/groups.py
@@ -41,7 +41,7 @@ async def search(
 
     Si l'utilisateur n'est pas encore vérifié, l’appel échouera et vous devrez vérifier l'utilisateur (cf. `/users/verify`).
 
-    Il est possible de passer en argument `acting_user_sub` qui permet de se passer d’un appel à `/user/verify`
+    NB : il est possible de vérifier automatiquement l’utilisateur en passant en argument `acting_user_sub`.
     """
 
     if acting_user_sub:

--- a/src/routers/groups_admin.py
+++ b/src/routers/groups_admin.py
@@ -18,16 +18,16 @@ router = APIRouter(
 @router.put("/{group_id}", response_model=GroupResponse)
 async def update_group(
     group_id: int = Path(..., description="The ID of the group to update"),
-    admin_id: int = Query(
-        ..., description="The user ID of the admin making the request"
-    ),
     group_name: str = Query(..., description="The new name of the group"),
+    active_user_sub: str = Query(
+        ..., description="The ProConnect sub of the user making the request"
+    ),
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
     Update a group (change its name).
     """
-    await groups_service.verify_user_is_admin(admin_id, group_id)
+    await groups_service.verify_user_is_admin(active_user_sub, group_id)
     return await groups_service.update_group(group_id, group_name)
 
 

--- a/src/routers/groups_admin.py
+++ b/src/routers/groups_admin.py
@@ -1,10 +1,11 @@
 # ------- USER ROUTER FILE -------
 from fastapi import APIRouter, Depends, Path, Query
+from pydantic import UUID4
 
 from src.auth import decode_access_token
 from src.dependencies import get_groups_service
 
-from ..models import GroupResponse
+from ..model import GroupResponse
 from ..services.groups import GroupsService
 
 router = APIRouter(
@@ -19,7 +20,7 @@ router = APIRouter(
 async def update_name(
     group_id: int = Path(..., description="ID de l’équipe"),
     group_name: str = Query(..., description="Nouveau nom"),
-    acting_user_sub: str = Query(
+    acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     groups_service: GroupsService = Depends(get_groups_service),
@@ -36,7 +37,7 @@ async def update_name(
 async def add_user(
     group_id: int = Path(..., description="ID de l’équipe"),
     user_id: int = Path(..., description="ID de l’utilisateur"),
-    acting_user_sub: str = Query(
+    acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     role_id: int = Query(..., description="ID du rôle"),
@@ -55,7 +56,7 @@ async def add_user(
 async def update_user_role(
     group_id: int = Path(..., description="ID de l’équipe"),
     user_id: int = Path(..., description="ID de l’utilisateur"),
-    acting_user_sub: str = Query(
+    acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     role_id: int = Query(..., description="ID du nouveau rôle"),
@@ -74,7 +75,7 @@ async def update_user_role(
 async def remove_user(
     group_id: int = Path(..., description="ID de l’équipe"),
     user_id: int = Path(..., description="ID de l’utilisateur"),
-    acting_user_sub: str = Query(
+    acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     groups_service: GroupsService = Depends(get_groups_service),

--- a/src/routers/groups_admin.py
+++ b/src/routers/groups_admin.py
@@ -27,7 +27,7 @@ async def update_name(
     """
     Mise à jour du nom d’une équipe.
     """
-    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
+    await groups_service.verify_acting_user_rights(acting_user_sub, group_id)
     return await groups_service.update_group(group_id, group_name)
 
 
@@ -47,7 +47,7 @@ async def add_user(
 
     Si le groupe, l’utilisateur ou le rôle n’existe pas, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
+    await groups_service.verify_acting_user_rights(acting_user_sub, group_id)
     return await groups_service.add_user_to_group(group_id, user_id, role_id)
 
 
@@ -66,7 +66,7 @@ async def update_user_role(
 
     Si le groupe, l’utilisateur ou le rôle n’existe pas, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
+    await groups_service.verify_acting_user_rights(acting_user_sub, group_id)
     return await groups_service.update_user_in_group(group_id, user_id, role_id)
 
 
@@ -84,5 +84,5 @@ async def remove_user(
 
     Si le groupe, ou l’utilisateur, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
+    await groups_service.verify_acting_user_rights(acting_user_sub, group_id)
     return await groups_service.remove_user_from_group(group_id, user_id)

--- a/src/routers/groups_admin.py
+++ b/src/routers/groups_admin.py
@@ -16,71 +16,73 @@ router = APIRouter(
 
 
 @router.put("/{group_id}", response_model=GroupResponse)
-async def update_group(
-    group_id: int = Path(..., description="The ID of the group to update"),
-    group_name: str = Query(..., description="The new name of the group"),
-    active_user_sub: str = Query(
-        ..., description="The ProConnect sub of the user making the request"
+async def update_name(
+    group_id: int = Path(..., description="ID de l’équipe"),
+    group_name: str = Query(..., description="Nouveau nom"),
+    acting_user_sub: str = Query(
+        ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Update a group (change its name).
+    Mise à jour du nom d’une équipe.
     """
-    await groups_service.verify_user_is_admin(active_user_sub, group_id)
+    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
     return await groups_service.update_group(group_id, group_name)
 
 
 # Group’s users manipulation
 @router.put("/{group_id}/users/{user_id}", status_code=201)
-async def add_user_to_group(
-    group_id: int = Path(..., description="The ID of the group"),
-    user_id: int = Path(..., description="The ID of the user"),
-    admin_id: int = Query(
-        ..., description="The user ID of the admin making the request"
+async def add_user(
+    group_id: int = Path(..., description="ID de l’équipe"),
+    user_id: int = Path(..., description="ID de l’utilisateur"),
+    acting_user_sub: str = Query(
+        ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
-    role_id: int = Query(..., description="The ID of the user's role"),
+    role_id: int = Query(..., description="ID du rôle"),
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Add a user to a given group with a specific role.
+    Ajout d’un utilisateur
 
-    If the group, the user or the role does not exist, a 404 error will be raised.
+    Si le groupe, l’utilisateur ou le rôle n’existe pas, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(admin_id, group_id)
+    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
     return await groups_service.add_user_to_group(group_id, user_id, role_id)
 
 
 @router.patch("/{group_id}/users/{user_id}", status_code=200)
-async def update_user_role_in_group(
-    group_id: int = Path(..., description="The ID of the group"),
-    user_id: int = Path(..., description="The ID of the user"),
-    admin_id: int = Query(
-        ..., description="The user ID of the admin making the request"
+async def update_user_role(
+    group_id: int = Path(..., description="ID de l’équipe"),
+    user_id: int = Path(..., description="ID de l’utilisateur"),
+    acting_user_sub: str = Query(
+        ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
-    role_id: int = Query(..., description="The ID of the role"),
+    role_id: int = Query(..., description="ID du nouveau rôle"),
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Update the role of a user in a specified group.
+    Met à jour le rôle d’un utilisateur dans une équipe
+
+    Si le groupe, l’utilisateur ou le rôle n’existe pas, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(admin_id, group_id)
+    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
     return await groups_service.update_user_in_group(group_id, user_id, role_id)
 
 
 @router.delete("/{group_id}/users/{user_id}", status_code=204)
-async def remove_user_from_group(
-    group_id: int = Path(..., description="The ID of the group"),
-    user_id: int = Path(..., description="The ID of the user"),
-    admin_id: int = Query(
-        ..., description="The user ID of the admin making the request"
+async def remove_user(
+    group_id: int = Path(..., description="ID de l’équipe"),
+    user_id: int = Path(..., description="ID de l’utilisateur"),
+    acting_user_sub: str = Query(
+        ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Remove a user from a given group
+    Retire un utilisateur d’une équipe.
 
-    If the group or the user does not exist, a 404 error will be raised.
+    Si le groupe, ou l’utilisateur, une erreur 404 sera levée.
     """
-    await groups_service.verify_user_is_admin(admin_id, group_id)
+    await groups_service.verify_user_is_admin(acting_user_sub, group_id)
     return await groups_service.remove_user_from_group(group_id, user_id)

--- a/src/routers/groups_scopes.py
+++ b/src/routers/groups_scopes.py
@@ -22,7 +22,9 @@ async def update_group_scopes(
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Update scopes or contract (that apply your service provider) to a specified group
+    Met à jour :
+    - les droits ou `scopes` d’une équipe sur votre fournisseur de service
+    - le contrat qui lie l’équipe à votre fournisseur de service
     """
     return await groups_service.update_scopes(
         group_id, scopes if scopes else "", contract if contract else ""

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -16,7 +16,7 @@ router = APIRouter(
 @router.get("/")
 async def ping(db: Database = Depends(get_db)):
     """
-    Health check endpoint to verify if the database is connected and the application is alive.
+    Vérifie l’état de la connexion à la base de données.
     """
     try:
         async with db.transaction():

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -32,8 +32,7 @@ async def ping(db: Database = Depends(get_db)):
             else:
                 raise Exception("Database query returned unexpected result")
 
-    except Exception as e:
-        print(e)
+    except Exception:
         # Log the exception here if needed
         return {
             "status": "unhealthy",

--- a/src/routers/roles.py
+++ b/src/routers/roles.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from src.auth import decode_access_token
 
 from ..dependencies import get_roles_service
-from ..models import RoleResponse
+from ..model import RoleResponse
 from ..services.roles import RolesService
 
 router = APIRouter(

--- a/src/routers/roles.py
+++ b/src/routers/roles.py
@@ -16,20 +16,20 @@ router = APIRouter(
 
 
 @router.get("/", response_model=list[RoleResponse])
-async def get_all_existing_roles(
+async def all(
     roles_service: RolesService = Depends(get_roles_service),
 ):
     """
-    Retrieve all existing roles
+    Retourne la liste des rôles existants.
+
+    Les rôles ne peuvent pas être créés ou supprimés. Si vous avez besoin d’un nouveau rôle, veuillez contacter l’équipe de dev.
     """
     return await roles_service.get_all_roles()
 
 
 @router.get("/{role_id}", response_model=RoleResponse, status_code=200)
-async def get_role_by_id(
-    role_id: int, roles_service: RolesService = Depends(get_roles_service)
-):
+async def by_id(role_id: int, roles_service: RolesService = Depends(get_roles_service)):
     """
-    Get a role by its ID.
+    Récupérer un role par son ID.
     """
     return await roles_service.get_roles_by_id(role_id)

--- a/src/routers/service_providers.py
+++ b/src/routers/service_providers.py
@@ -22,7 +22,7 @@ async def get_service_provider_info(
     ),
 ):
     """
-    Get the details of the service provider paired with your service account.
+    Récupère les informations du fournisseur de service associé au compte de service.
     """
     return await service_providers_service.get_service_provider_by_id(
         service_provider_id

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -17,28 +17,49 @@ router = APIRouter(
 
 
 @router.post("/", response_model=UserResponse, status_code=201)
-async def create_user(
+async def create(
     user: UserCreate, users_service: UsersService = Depends(get_users_service)
-):
+) -> UserResponse:
+    """
+    Crée l’utilisateur dans la base de données.
+
+    L’utilisateur doit être un utilisateur ProConnect existant.
+    """
     return await users_service.create_user(user)
 
 
 @router.get("/search", response_model=UserResponse)
-async def get_user_by_email(
+async def by_email(
     email: EmailStr,
     users_service: UsersService = Depends(get_users_service),
 ) -> UserResponse:
     """
-    Get a specific user by email
+    Retourne un utilisateur identifié par son adresse e-mail.
     """
     return await users_service.get_user_by_email(email=email)
 
 
 @router.get("/{user_id}", status_code=200)
-async def get_user_by_id(
+async def by_id(
     user_id: int, users_service: UsersService = Depends(get_users_service)
 ) -> UserResponse:
     """
-    Get a user by ID
+    Retourne un utilisateur identifié par son ID.
     """
     return await users_service.get_user_by_id(user_id)
+
+
+@router.patch("/verify", status_code=200)
+async def confirm_user(
+    user_email: EmailStr,
+    user_sub: str,
+    users_service: UsersService = Depends(get_users_service),
+) -> None:
+    """
+    Vérifie/confirme un utilisateur et enregistre son sub ProConnect
+
+    Un utilisateur est non vérifié lors de sa création.
+
+    Un utilisateur non vérifié ne peut pas accomplir les actions d’administration d’équipe
+    """
+    return await users_service.verify_user(user_email, user_sub)

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -24,6 +24,10 @@ async def create(
     Crée l’utilisateur dans la base de données.
 
     L’utilisateur doit être un utilisateur ProConnect existant.
+
+    Quand l'utilisateur est créé, il est encore non vérifié. Un appel à l'endpoint `/users/verify` permet de le confirmer avec son sub ProConnect.
+
+    Cela permet de créér un utilisateur et de l’ajouter à une équipe sans connaitre son sub.
     """
     return await users_service.create_user(user)
 
@@ -56,10 +60,10 @@ async def confirm_user(
     users_service: UsersService = Depends(get_users_service),
 ) -> None:
     """
-    Vérifie/confirme un utilisateur et enregistre son sub ProConnect
+    Vérifie un utilisateur en enregistrant son sub ProConnect
 
     Un utilisateur est non vérifié lors de sa création.
 
-    Un utilisateur non vérifié ne peut pas accomplir les actions d’administration d’équipe
+    Attention, il est impossible de récupérer les groupes d’un utilisateur non vérifié
     """
     return await users_service.verify_user(user_email, user_sub)

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -1,11 +1,11 @@
 # ------- USER ROUTER FILE -------
 from fastapi import APIRouter, Depends
-from pydantic import EmailStr
+from pydantic import UUID4, EmailStr
 
 from src.auth import decode_access_token
 
 from ..dependencies import get_users_service
-from ..models import UserCreate, UserResponse
+from ..model import UserCreate, UserResponse
 from ..services.users import UsersService
 
 router = APIRouter(
@@ -56,7 +56,7 @@ async def by_id(
 @router.patch("/verify", status_code=200)
 async def confirm_user(
     user_email: EmailStr,
-    user_sub: str,
+    user_sub: UUID4,
     users_service: UsersService = Depends(get_users_service),
 ) -> None:
     """

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -36,7 +36,7 @@ async def by_email(
     """
     Retourne un utilisateur identifié par son adresse e-mail.
     """
-    return await users_service.get_user_by_email(email=email)
+    return await users_service.get_user_by_email(email=email, only_verified_user=False)
 
 
 @router.get("/{user_id}", status_code=200)
@@ -46,7 +46,7 @@ async def by_id(
     """
     Retourne un utilisateur identifié par son ID.
     """
-    return await users_service.get_user_by_id(user_id)
+    return await users_service.get_user_by_id(user_id, only_verified_user=False)
 
 
 @router.patch("/verify", status_code=200)

--- a/src/services/auth.py
+++ b/src/services/auth.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException, status
 
 from src.auth import verify_password
-from src.models import ServiceAccountResponse
+from src.model import ServiceAccountResponse
 from src.repositories.auth import AuthRepository
 
 

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -1,9 +1,9 @@
 from fastapi import HTTPException, status
-from pydantic import EmailStr
+from pydantic import UUID4, EmailStr
 
 from src.services.services_provider import ServiceProvidersService
 
-from ..models import (
+from ..model import (
     GroupCreate,
     GroupResponse,
     GroupWithUsersAndScopesResponse,
@@ -51,7 +51,7 @@ class GroupsService:
             )
 
     async def verify_acting_user_rights(
-        self, acting_user_sub: str, group_id: int
+        self, acting_user_sub: UUID4, group_id: int
     ) -> None:
         """
         Verify if the user is an admin of the group.

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -49,19 +49,19 @@ class GroupsService:
                 status_code=status.HTTP_400_BAD_REQUEST, detail="Siren is required."
             )
 
-    async def verify_user_is_admin(self, admin_id: int, group_id: int) -> None:
+    async def verify_user_is_admin(self, acting_user_sub: str, group_id: int) -> None:
         """
         Verify if the user is an admin of the group.
         """
         # verify usert exists and group exists
-        await self.users_service.get_user_by_id(admin_id)
+        acting_user = await self.users_service.get_user_by_sub(acting_user_sub)
         await self.get_group_by_id(group_id)
 
         group_users = await self.users_service.get_users_by_group_id(group_id)
-        if admin_id not in [u.id for u in group_users]:
+        if acting_user.id not in [u.id for u in group_users]:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"User with ID {admin_id} is not admin of the group.",
+                detail=f"User with sub {acting_user_sub} is not admin of the group.",
             )
 
     async def get_group_by_id(self, group_id: int) -> GroupResponse:

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException, status
+from pydantic import EmailStr
 
 from src.services.services_provider import ServiceProvidersService
 
@@ -105,12 +106,15 @@ class GroupsService:
     async def list_groups(self) -> list[GroupResponse]:
         return await self.groups_repository.list_groups(self.service_provider_id)
 
-    async def search_groups(self, email: str) -> list[GroupWithUsersAndScopesResponse]:
+    async def search_groups(
+        self, email: EmailStr
+    ) -> list[GroupWithUsersAndScopesResponse]:
         """
-        Search for groups by user email.
+        Search for groups by ProConnect sub.
 
         This method will return all groups that the user is a member of, regardless of their role.
         """
+
         user = await self.users_service.get_user_by_email(email)
         groups = await self.groups_repository.search_groups_by_user(
             user.id, self.service_provider_id

--- a/src/services/organisations.py
+++ b/src/services/organisations.py
@@ -1,23 +1,10 @@
-from ..models import OrganisationCreate
+from ..model import OrganisationCreate
 from ..repositories.organisations import OrganisationsRepository
 
 
 class OrganisationsService:
     def __init__(self, organisations_repository: OrganisationsRepository):
         self.organisations_repository = organisations_repository
-
-    async def validate_organisation_data(
-        self, organisation_data: OrganisationCreate
-    ) -> None:
-        """
-        Validate the organisation data
-        """
-        if not organisation_data.siren:
-            raise ValueError("Siren is required.")
-        if not isinstance(organisation_data.siren, str):
-            raise ValueError("Siren must be a string.")
-        if len(organisation_data.siren) != 9 or not organisation_data.siren.isdigit():
-            raise ValueError("Siren must be a 9-digit number.")
 
     async def get_or_create_organisation(
         self, organisation_data: OrganisationCreate
@@ -27,8 +14,6 @@ class OrganisationsService:
 
         Create it if it doesn't exist
         """
-        await self.validate_organisation_data(organisation_data)
-
         organisation = await self.organisations_repository.get_organisation(
             organisation_data
         )

--- a/src/services/scopes.py
+++ b/src/services/scopes.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, status
 
-from src.models import ScopeBase
+from src.model import ScopeBase
 from src.repositories.scopes import ScopesRepository
 
 

--- a/src/services/services_provider.py
+++ b/src/services/services_provider.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, status
 
-from src.models import ServiceProviderResponse
+from src.model import ServiceProviderResponse
 from src.repositories.service_providers import ServiceProvidersRepository
 
 

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -37,6 +37,18 @@ class UsersService:
             )
         return user
 
+    async def get_user_by_sub(self, user_sub: str) -> UserResponse:
+        """
+        Retrieve user by it's ProConnect sub
+        """
+        user = await self.user_repository.get_user_by_sub(user_sub)
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User with sub {user_sub} not found",
+            )
+        return user
+
     async def get_users_by_group_id(self, group_id: int) -> list[UserWithRoleResponse]:
         """
         Retrieve all user for a given group ID

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -2,8 +2,9 @@
 from xmlrpc.client import boolean
 
 from fastapi import HTTPException, status
+from pydantic import UUID4
 
-from ..models import UserCreate, UserResponse, UserWithRoleResponse
+from ..model import UserCreate, UserResponse, UserWithRoleResponse
 from ..repositories.users import UsersRepository
 
 
@@ -15,7 +16,7 @@ class UsersService:
         if not user_data.email:
             raise ValueError("Email is required.")
 
-    async def verify_user(self, user_email: str, user_sub: str):
+    async def verify_user(self, user_email: str, user_sub: UUID4):
         user = await self.get_user_by_email(user_email, only_verified_user=False)
         if user and not user.is_verified:
             await self.user_repository.verify_user(user_email, user_sub)
@@ -58,7 +59,7 @@ class UsersService:
             )
         return user
 
-    async def get_user_by_sub(self, user_sub: str) -> UserResponse:
+    async def get_user_by_sub(self, user_sub: UUID4) -> UserResponse:
         """
         Retrieve user by it's ProConnect sub
         """

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -1,4 +1,6 @@
 # ------- SERVICE FILE -------
+from xmlrpc.client import boolean
+
 from fastapi import HTTPException, status
 
 from ..models import UserCreate, UserResponse, UserWithRoleResponse
@@ -14,13 +16,13 @@ class UsersService:
             raise ValueError("Email is required.")
 
     async def verify_user(self, user_email: str, user_sub: str):
-        # Verify if the user exists
-        user = await self.get_user_by_email(user_email)
-
-        if not user.is_verified:
+        user = await self.get_user_by_email(user_email, only_verified_user=False)
+        if user and not user.is_verified:
             await self.user_repository.verify_user(user_email, user_sub)
 
-    async def get_user_by_email(self, email: str) -> UserResponse:
+    async def get_user_by_email(
+        self, email: str, only_verified_user: boolean = True
+    ) -> UserResponse:
         """
         Retrieve user by email
         """
@@ -30,14 +32,16 @@ class UsersService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"User with email {email} not found",
             )
-        if not user.is_verified:
+        if only_verified_user and not user.is_verified:
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail="User is not yet verified.",
             )
         return user
 
-    async def get_user_by_id(self, user_id: int) -> UserResponse:
+    async def get_user_by_id(
+        self, user_id: int, only_verified_user: boolean = True
+    ) -> UserResponse:
         """
         Retrieve user by ID
         """
@@ -47,7 +51,7 @@ class UsersService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"User with ID {user_id} not found",
             )
-        if not user.is_verified:
+        if only_verified_user and not user.is_verified:
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail="User is not yet verified.",
@@ -62,7 +66,7 @@ class UsersService:
         if not user:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"User with sub {user_sub} is not found, either it does not exist or it is not yet verified",
+                detail=f"User with sub {user_sub} is not found, either it does not exist or it is not verified",
             )
         return user
 

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -18,7 +18,7 @@ def random_group():
 
 def random_sub_pro_connect():
     """Generate a random sub ProConnect."""
-    return f"sub_{uuid4()}"
+    return uuid4()
 
 
 def random_user():

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -16,6 +16,11 @@ def random_group():
     }
 
 
+def random_sub_pro_connect():
+    """Generate a random sub ProConnect."""
+    return f"sub_{uuid4()}"
+
+
 def random_user():
     """Generate a random user for testing."""
     return {"email": f"test_{uuid4()}@example.com", "sub_pro_connect": f"sub_{uuid4()}"}
@@ -35,3 +40,11 @@ def create_group(client):
     assert group["name"] == new_group_data["name"]
     new_group_data["id"] = group["id"]
     return new_group_data
+
+
+def verify_user(client, user_email, user_sub):
+    """Verify a user by email and sub."""
+    response = client.patch(
+        "/users/verify", params={"user_email": user_email, "user_sub": user_sub}
+    )
+    assert response.status_code == 200

--- a/src/tests/integration/test_3_users.py
+++ b/src/tests/integration/test_3_users.py
@@ -21,7 +21,6 @@ def test_get_user_by_id(client):
     create_response = client.post("/users/", json=user_data)
     user_id = create_response.json()["id"]
 
-    # Now get the user by ID
     response = client.get(f"/users/{user_id}")
 
     # This should succeed but has a bug (no return statement in the route)

--- a/src/tests/integration/test_3_users.py
+++ b/src/tests/integration/test_3_users.py
@@ -1,4 +1,4 @@
-from src.tests.helpers import random_user
+from src.tests.helpers import random_sub_pro_connect, random_user
 
 
 def test_create_user(client):
@@ -55,3 +55,25 @@ def test_get_user_by_email(client):
     # Verify not found case
     response = client.get("/users/search", params={"email": "notfound@example.com"})
     assert response.status_code == 404
+
+
+def test_uuid_format(client):
+    """Test that the user ID is in UUID format."""
+    user_data = random_user()
+    response = client.post("/users/", json=user_data)
+    user = response.json()
+
+    response_verify = client.patch(
+        "/users/verify",
+        params={"user_email": user["email"], "user_sub": "blbabla_test"},
+    )
+
+    # not a valid uuid v4
+    assert response_verify.status_code == 422
+
+    response_verify_ok = client.patch(
+        "/users/verify",
+        params={"user_email": user["email"], "user_sub": random_sub_pro_connect()},
+    )
+
+    assert response_verify_ok.status_code == 200

--- a/src/tests/integration/test_4_groups.py
+++ b/src/tests/integration/test_4_groups.py
@@ -80,7 +80,8 @@ def test_search_group_by_user(client):
 
     # Test non-existent user
     response404 = client.get(
-        "/groups/search", params={"email": "hey@test.fr", "acting_user_sub": random_sub}
+        "/groups/search",
+        params={"email": "hey@test.fr", "acting_user_sub": random_sub_pro_connect()},
     )
     assert response404.status_code == 404
 
@@ -89,7 +90,7 @@ def test_search_group_by_user(client):
         "/groups/search",
         params={
             "email": "user-not-in-group@beta.gouv.fr",
-            "acting_user_sub": random_sub,
+            "acting_user_sub": random_sub_pro_connect(),
         },
     )
     assert responseEmpty.status_code == 200

--- a/src/tests/integration/test_4_groups.py
+++ b/src/tests/integration/test_4_groups.py
@@ -27,6 +27,26 @@ def test_create_group(client):
     assert group["contract"] == new_group["contract"]
     assert group["users"][0]["email"] == new_group["admin_email"]
 
+    new_group_bad_siren = create_group(client)
+    new_group_bad_siren["organisation_siren"] = "aaaaaaaaa"
+    response = client.post("/groups/", json=new_group_bad_siren)
+    # invalid siren should return 400
+    assert response.status_code == 400
+
+    new_group_no_siren = create_group(client)
+    del new_group_no_siren["organisation_siren"]
+
+    response = client.post("/groups/", json=new_group_no_siren)
+    # invalid siren should return 400
+    assert response.status_code == 422
+
+    new_group_empty_siren = create_group(client)
+    new_group_empty_siren["organisation_siren"] = ""
+
+    response = client.post("/groups/", json=new_group_empty_siren)
+    # invalid siren should return 400
+    assert response.status_code == 400
+
 
 def test_get_group_with_users(client):
     """Test retrieving a group with its users."""

--- a/src/tests/integration/test_6_groups_admin.py
+++ b/src/tests/integration/test_6_groups_admin.py
@@ -18,7 +18,8 @@ def test_update_group(client):
     responseNotVerified = client.put(
         f"/groups/{new_group_data["id"]}?acting_user_sub={admin_sub}&group_name={new_name}"
     )
-    assert responseNotVerified.status_code == 423
+    # sub should be unknown, so the request should fail
+    assert responseNotVerified.status_code == 404
 
     verify_user(client, admin_email, admin_sub)
     response = client.put(
@@ -86,7 +87,9 @@ def test_add_user_to_group_and_update_roles(client):
     responseNotVerified = client.put(
         f"/groups/{new_group_data["id"]}/users/{user_id}?acting_user_sub={admin_sub}&role_id={role_1['id']}"
     )
-    assert responseNotVerified.status_code == 423
+
+    # sub should be unknown, so the request should fail
+    assert responseNotVerified.status_code == 404
 
     verify_user(client, admin_email, admin_sub)
 
@@ -124,21 +127,22 @@ def test_remove_user_from_group(client):
 
     user_data = random_user()
 
-    user_response = client.post("/users/", json=user_data)
-    user_id = user_response.json()["id"]
+    create_user_response = client.post("/users/", json=user_data)
+    user_id = create_user_response.json()["id"]
 
     roles_response = client.get("/roles/")
     role_id = roles_response.json()[0]["id"]
 
-    responseNotVerified = client.post(
+    responseNotVerified = client.patch(
         f"/groups/{new_group_data['id']}/users/{user_id}?acting_user_sub={admin_sub}&role_id={role_id}"
     )
-    assert responseNotVerified.status_code == 423
+    # sub should be unknown, so the request should fail
+    assert responseNotVerified.status_code == 404
 
     verify_user(client, admin_email, admin_sub)
 
     # Add user to group
-    client.post(
+    client.patch(
         f"/groups/{new_group_data['id']}/users/{user_id}?acting_user_sub={admin_sub}&role_id={role_id}"
     )
 

--- a/src/tests/unit/test_siren.py
+++ b/src/tests/unit/test_siren.py
@@ -1,0 +1,41 @@
+# Test cases
+import pytest
+from fastapi import HTTPException
+
+from src.model import validate_siren
+
+
+@pytest.fixture
+def valid_test_sirens():
+    """Fixture providing valid SIRENs for testing."""
+    return ["732829320", "440117620", "130020649", "356000000"]
+
+
+@pytest.fixture
+def invalid_test_sirens():
+    """Fixture providing invalid SIRENs for testing."""
+    return [
+        ("123456789", "fails Luhn checksum"),
+        ("000000000", "fails Luhn checksum"),
+        ("12345678", "9-digit string"),
+        ("1234567890", "9-digit string"),
+        ("aaaaaaaaa", "9-digit string"),
+        ("1234567", "9-digit string"),
+    ]
+
+
+def test_valid_sirens_with_fixture(valid_test_sirens):
+    """Test valid SIRENs using fixture."""
+    for siren in valid_test_sirens:
+        result = validate_siren(siren)
+        assert result == siren
+
+
+def test_invalid_sirens_with_fixture(invalid_test_sirens):
+    """Test invalid SIRENs using fixture."""
+    for siren, expected_error_fragment in invalid_test_sirens:
+        with pytest.raises(HTTPException) as exc_info:
+            validate_siren(siren)
+
+        assert exc_info.value.status_code == 400
+        assert expected_error_fragment in exc_info.value.detail


### PR DESCRIPTION
- [x] use proconnect sub rather than user ID to check for admin rights over group manipulation
- [x] need to find a way to update proconnect sub on first connexion as it is not required for user creation
- [x] ensure it is impossible to remove admin or to change it's role when it is the only admin in team

closes #35 
closes #39  