### PR TITLE
fix: missing     expires_in in response model

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -156,3 +156,4 @@ class ServiceAccountResponse(ServiceAccountBase):
 class Token(BaseModel):
     access_token: str
     token_type: str = "bearer"
+    expires_in: int


### PR DESCRIPTION
Missing field is model means it is not included in response