### PR TITLE
update deployment workflow: deployments based on commit messages

### DIFF
--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -3,44 +3,80 @@ run-name: create and deploy ${{ github.sha }}
 on:
   push:
     branches:
-      - main
+      - '*'
 jobs:
   trigger-gitlab-pipeline:
+    if: |
+      startsWith(github.event.head_commit.message, '[')
     runs-on: ubuntu-latest
     env:
-      # static variables and secrets to be defined
+      # variables to be defined
       APP_NAME: ${{ vars.APP_NAME }}
       SCAFFOLD_REPO_SSH_URL: ${{ vars.SCAFFOLD_REPO_SSH_URL }}
-      SCAFFOLD_DIR: "scaffold"
-      ENV: ""
+      ENVS: ${{ vars.ENVS }}
+
+      # secrets to be defined
       GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
       DEPLOY_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
     steps:
       - name: configure environment
         shell: bash
         run: |
+          # configure environment variables
+          echo "REPO_HTTPS_URL=${{ github.server_url }}/${{ github.repository }}.git" >> $GITHUB_ENV
+          echo "REPO_SSH_URL=git@github.com:${{ github.repository }}.git" >> $GITHUB_ENV
+          echo "REPO_CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+          echo "SCAFFOLD_DIR=scaffold" >> $GITHUB_ENV
+
           # configure the SSH deploy private key
           mkdir -p ~/.ssh
           echo "$DEPLOY_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
 
           # configure git
           git config --global user.email "root@data.gouv.fr"
           git config --global user.name "datagouv"
 
-          # set ENV based on branch
-          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            echo "ENV=preprod" >> $GITHUB_ENV
-          fi
-      - name: clone scaffold repository
+      - name: clone repositories
         shell: bash
         run: |
-          git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL $SCAFFOLD_DIR
+          git clone --quiet --depth 1 -b ${{ env.REPO_CURRENT_BRANCH }} ${{ env.REPO_SSH_URL }}
+          git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL ${{ env.SCAFFOLD_DIR }}
+
+      - name: check commit message
+        shell: bash
+        run: |
+          LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%s)
+
+          if [[ $LAST_COMMIT_MESSAGE =~ ^\[($ENVS):(major|minor|patch)\] ]]; then
+            ENV="${BASH_REMATCH[1]}"
+            VERSION_PART="${BASH_REMATCH[2]}"
+          else
+            echo "error: invalid env and/or version part"
+            exit 1
+          fi
+
+          echo "ENV=$ENV" >> $GITHUB_ENV
+          echo "VERSION_PART=$VERSION_PART" >> $GITHUB_ENV
+        working-directory: ${{ env.APP_NAME }}
+
+      - name: create release
+        shell: bash
+        run: |
+          pattern="${APP_NAME}-${ENV}-[0-9]+\.[0-9]+\.[0-9]+$"
+          tags=$(git ls-remote --tags origin | grep -Eo "refs/tags/${pattern}" | sed 's#refs/tags/##' || true)
+          if [ -n "$tags" ]; then
+              for tag in $tags; do git fetch origin tag $tag; done
+          fi
+          RELEASE_VERSION=$(../${{ env.SCAFFOLD_DIR }}/scripts/bump_version_non_semver.sh $APP_NAME $ENV $VERSION_PART)
+
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+        working-directory: ${{ env.APP_NAME }}
+
       - name: trigger Gitlab CI/CD pipeline
         shell: bash
         run: |
-          RELEASE_VERSION="${GITHUB_SHA:0:8}"
-
           ./scripts/gitlab-ci-pipeline.sh $APP_NAME $RELEASE_VERSION $ENV ""
         working-directory: ${{ env.SCAFFOLD_DIR }}

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,6 @@ admin_update_service_account:
 	uv run python -m admin.update-service-account
 
 deploy:
-	@read -p "Enter env (prod,staging, dev): " env && \
+	@read -p "Enter env (www,staging, dev): " env && \
 	read -p "Enter version (minor, major, patch): " version && \
 	SKIP=conventional-pre-commit git commit -m "[$$env:$$version]"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
+
 start:
 	uv run fastapi dev src/main.py
 
@@ -33,3 +34,8 @@ admin_create_service_account:
 
 admin_update_service_account:
 	uv run python -m admin.update-service-account
+
+deploy:
+	@read -p "Enter env (prod,staging, dev): " env && \
+	read -p "Enter version (minor, major, patch): " version && \
+	SKIP=conventional-pre-commit git commit -m "[$$env:$$version]"


### PR DESCRIPTION
Update deployment workflow to trigger deployments based on:
- `ENV`: `www`, `preprod` or `dev`
- `VERSION_PART`: `major`, `minor` or `patch`.

All variables and secrets needed for this workflow are listed in `env:` section.
Each trigger will create and push a new tag, depending of the `VERSION_PART`. This tag will be used when building the image and during deployment.

Both the configuration & workflow are retrieved/triggered based on commit message.
The commit message format is: `[<env>:<version_part>] <description>`.
For example: `[dev:minor] new incredible feature`.

The workflow is in charge of:
- configuring environment (ie. variables and repository access)
- cloning both scaffolding and application repositories
- retrieving configuration based on commit message
- create and push a new tag
- trigger an internal Gitlab CI/CD pipeline.