### PR TITLE
feat: return user ID, add URL and description

### DIFF
--- a/.github/workflows/docker-config-test.yml
+++ b/.github/workflows/docker-config-test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run health checks
       run: |
         # Test postgres connection
-        docker compose exec -T postgres-local psql -U d-roles -d d-roles -c "SELECT contract FROM d_roles.group_service_provider_relations;"
+        docker compose exec -T postgres-local psql -U d-roles -d d-roles -c "SELECT contract_url FROM d_roles.group_service_provider_relations;"
 
         # Test app health endpoint
         curl -f http://localhost/health/

--- a/db/migrations/20250717.sql
+++ b/db/migrations/20250717.sql
@@ -1,0 +1,13 @@
+\set schema_name :DB_SCHEMA
+
+BEGIN;
+
+-- Add URL column to service_providers table
+ALTER TABLE :schema_name.service_providers
+ADD COLUMN url VARCHAR(500) CHECK (url IS NULL OR url ~ '^https?://');
+
+-- Add description column to group_service_provider_relations table
+ALTER TABLE :schema_name.group_service_provider_relations
+ADD COLUMN description TEXT DEFAULT NULL;
+
+COMMIT;

--- a/db/migrations/20250717.sql
+++ b/db/migrations/20250717.sql
@@ -8,6 +8,11 @@ ADD COLUMN url VARCHAR(500) CHECK (url IS NULL OR url ~ '^https?://');
 
 -- Add description column to group_service_provider_relations table
 ALTER TABLE :schema_name.group_service_provider_relations
-ADD COLUMN description TEXT DEFAULT NULL;
+ADD COLUMN contract_url VARCHAR(500) CHECK (contract_url IS NULL OR contract_url ~ '^https?://');
+
+-- Rename contract column to contract_description in group_service_provider_relations
+ALTER TABLE :schema_name.group_service_provider_relations
+RENAME COLUMN contract TO contract_description;
+
 
 COMMIT;

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -39,8 +39,8 @@ VALUES
   (1, 5, 2) ON CONFLICT (group_id, user_id) DO NOTHING;
 
 -- Add the "read" scope for the group on the service provider "test"
-INSERT INTO :schema_name.group_service_provider_relations (service_provider_id, group_id, scopes, contract, description)
-VALUES (1, 1, 'administrateur rne nonDiffusible conformite beneficiaires agent pseudo_opendata effectifs_annuels chiffre_affaires travaux_publics liens_capitalistiques liasses_fiscales bilans_bdf', 'datapass_48', 'Habilitation de test') ON CONFLICT (service_provider_id, group_id) DO NOTHING;
+INSERT INTO :schema_name.group_service_provider_relations (service_provider_id, group_id, scopes, contract_description, contract_url)
+VALUES (1, 1, 'administrateur rne nonDiffusible conformite beneficiaires agent pseudo_opendata effectifs_annuels chiffre_affaires travaux_publics liens_capitalistiques liasses_fiscales bilans_bdf', 'Habilitation de test', 'https://datapass_48') ON CONFLICT (service_provider_id, group_id) DO NOTHING;
 
 -- Insert a service account for a service provider
 INSERT INTO :schema_name.service_accounts (

--- a/db/seed/seed.sql
+++ b/db/seed/seed.sql
@@ -24,8 +24,8 @@ VALUES
   (5, 'amandine.audras@beta.gouv.fr', false) ON CONFLICT (id) DO NOTHING;
 
 -- Create the service provider "test"
-INSERT INTO :schema_name.service_providers (id, name)
-VALUES (1, 'droles-test') ON CONFLICT (id) DO NOTHING;
+INSERT INTO :schema_name.service_providers (id, name, url)
+VALUES (1, 'droles-test', 'https://data.gouv.fr') ON CONFLICT (id) DO NOTHING;
 
 -- Add the users to the group with their respective roles
 -- User 1 is an admin (role_id = 1)
@@ -39,8 +39,8 @@ VALUES
   (1, 5, 2) ON CONFLICT (group_id, user_id) DO NOTHING;
 
 -- Add the "read" scope for the group on the service provider "test"
-INSERT INTO :schema_name.group_service_provider_relations (service_provider_id, group_id, scopes, contract)
-VALUES (1, 1, 'administrateur rne nonDiffusible conformite beneficiaires agent pseudo_opendata effectifs_annuels chiffre_affaires travaux_publics liens_capitalistiques liasses_fiscales bilans_bdf', 'datapass_48') ON CONFLICT (service_provider_id, group_id) DO NOTHING;
+INSERT INTO :schema_name.group_service_provider_relations (service_provider_id, group_id, scopes, contract, description)
+VALUES (1, 1, 'administrateur rne nonDiffusible conformite beneficiaires agent pseudo_opendata effectifs_annuels chiffre_affaires travaux_publics liens_capitalistiques liasses_fiscales bilans_bdf', 'datapass_48', 'Habilitation de test') ON CONFLICT (service_provider_id, group_id) DO NOTHING;
 
 -- Insert a service account for a service provider
 INSERT INTO :schema_name.service_accounts (

--- a/src/documentation.py
+++ b/src/documentation.py
@@ -53,15 +53,15 @@ api_tags_metadata = [
         "description": "Les rôles disponibles pour les utilisateurs (les utilisateurs sont indépendants du fournisseur de service)",
     },
     {
-        "name": "Équipes",
-        "description": "Création, et récupération des équipes",
+        "name": "Groupes",
+        "description": "Création, et récupération des groupes",
     },
     {
-        "name": "Administration d’une équipe",
-        "description": "Doit nécessairement être executé par un administrateur de l’équipe",
+        "name": "Administration d’une groupe",
+        "description": "Doit nécessairement être executé par un administrateur de l’groupe",
     },
     {
-        "name": "Gestion des droits d’une équipe",
-        "description": "Permet de gérer les droits d’accès d’une équipe sur un fournisseur de service",
+        "name": "Gestion des droits d’une groupe",
+        "description": "Permet de gérer les droits d’accès d’une groupe sur un fournisseur de service",
     },
 ]

--- a/src/documentation.py
+++ b/src/documentation.py
@@ -20,7 +20,7 @@ Tous les utilisateurs du groupe de John héritent du scope `ecriture` sur ma-sta
 
 **Fournisseur de service** : un produit numérique (ex: une startup d’état)
 
-**Scope** : la description des droits d’accès dont dispose une équipe, sur un fournisseur de service (ex: `ecriture` ou `lecture`)
+**Scope** : la description des droits d’accès dont dispose un groupe, sur un fournisseur de service (ex: `ecriture` ou `lecture`)
 
 
 ## Utilisation

--- a/src/model.py
+++ b/src/model.py
@@ -94,8 +94,8 @@ class GroupCreate(GroupBase):
     organisation_siret: Siret
     admin: UserCreate
     scopes: str | None
-    contract: str | None
-    description: str | None = None
+    contract_description: str | None
+    contract_url: HttpUrl | None = None
     members: list[UserCreate] | None = None
 
 
@@ -114,7 +114,8 @@ class GroupWithUsersAndScopesResponse(GroupResponse):
     organisation_siret: Siret
     users: list[UserWithRoleResponse]
     scopes: str
-    contract: str
+    contract_description: str | None
+    contract_url: HttpUrl | None = None
 
 
 class ParentChildCreate(BaseModel):
@@ -146,7 +147,8 @@ class RoleResponse(RoleBase):
 # --- Service Provider & scopes ---
 class ScopeBase(BaseModel):
     scopes: str  # Consider using list[str] if representing multiple scopes
-    contract: str
+    contract_description: str | None
+    contract_url: HttpUrl | None = None
 
 
 class ScopeResponse(ScopeBase):

--- a/src/model.py
+++ b/src/model.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from xmlrpc.client import boolean
 
 from fastapi import HTTPException, status
-from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr, Field, HttpUrl
 
 
 def validate_siret(v: str) -> str:
@@ -91,10 +91,11 @@ class GroupBase(BaseModel):
 
 
 class GroupCreate(GroupBase):
-    organisation_siret: Siret  # type: ignore # Optional for group creation
+    organisation_siret: Siret
     admin: UserCreate
     scopes: str | None
     contract: str | None
+    description: str | None = None
     members: list[UserCreate] | None = None
 
 
@@ -157,6 +158,7 @@ class ScopeResponse(ScopeBase):
 
 class ServiceProviderBase(BaseModel):
     name: str
+    url: HttpUrl | None
 
 
 class ServiceProviderResponse(ServiceProviderBase):

--- a/src/repositories/admin/admin_write_repository.py
+++ b/src/repositories/admin/admin_write_repository.py
@@ -98,14 +98,13 @@ class AdminWriteRepository:
             )
 
     async def create_service_provider(
-        self,
-        name: str,
+        self, name: str, url: str
     ) -> ServiceProviderResponse:
         async with self.db_session.transaction():
             query = """
-                INSERT INTO service_providers (name, created_at, updated_at)
-                VALUES (:name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                INSERT INTO service_providers (name, url, created_at, updated_at)
+                VALUES (:name, :url, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                 RETURNING *
             """
-            values = {"name": name}
+            values = {"name": name, "url": url}  # URL is optional, can be set later
             return await self.db_session.fetch_one(query, values)

--- a/src/repositories/groups.py
+++ b/src/repositories/groups.py
@@ -62,7 +62,7 @@ class GroupsRepository:
     ) -> list[GroupWithUsersAndScopesResponse]:
         async with self.db_session.transaction():
             query = """
-            SELECT G.id, G.name, O.siret as organisation_siret, GSPR.scopes, GSPR.contract
+            SELECT G.id, G.name, O.siret as organisation_siret, GSPR.scopes, GSPR.contract_description, GSPR.contract_url
             FROM groups as G
             INNER JOIN organisations AS O ON G.orga_id = O.id
             INNER JOIN group_user_relations AS GUR ON GUR.group_id = G.id
@@ -87,14 +87,19 @@ class GroupsRepository:
                 query_create_group, {"name": group_data.name, "orga_id": orga_id}
             )
 
-            query_create_access = "INSERT INTO group_service_provider_relations (service_provider_id, group_id, scopes, contract) VALUES (:service_provider_id, :group_id, :scopes, :contract)"
+            query_create_access = "INSERT INTO group_service_provider_relations (service_provider_id, group_id, scopes, contract_description, contract_url) VALUES (:service_provider_id, :group_id, :scopes, :contract_description, :contract_url)"
             await self.db_session.execute(
                 query_create_access,
                 {
                     "service_provider_id": service_provider_id,
                     "group_id": new_group.id,
                     "scopes": group_data.scopes if group_data.scopes else "",
-                    "contract": group_data.contract if group_data.contract else "",
+                    "contract_description": group_data.contract_description
+                    if group_data.contract_description
+                    else "",
+                    "contract_url": group_data.contract_url
+                    if group_data.contract_url
+                    else "",
                 },
             )
 
@@ -107,7 +112,12 @@ class GroupsRepository:
                     "name": new_group.name,
                     "orga_id": orga_id,
                     "scopes": group_data.scopes if group_data.scopes else "",
-                    "contract": group_data.contract if group_data.contract else "",
+                    "contract_description": group_data.contract_description
+                    if group_data.contract_description
+                    else "",
+                    "contract_url": group_data.contract_url
+                    if group_data.contract_url
+                    else "",
                 },
             )
 

--- a/src/repositories/groups.py
+++ b/src/repositories/groups.py
@@ -49,6 +49,7 @@ class GroupsRepository:
             FROM groups as G
             INNER JOIN organisations AS O ON G.orga_id = O.id
             INNER JOIN group_service_provider_relations AS GSPR ON GSPR.group_id = G.id AND GSPR.service_provider_id = :service_provider_id
+            ORDER BY G.id
             """
             return await self.db_session.fetch_all(
                 query,
@@ -69,6 +70,7 @@ class GroupsRepository:
             INNER JOIN users AS U ON U.id = GUR.user_id
             INNER JOIN group_service_provider_relations AS GSPR ON GSPR.group_id = G.id AND GSPR.service_provider_id = :service_provider_id
             WHERE U.id = :user_id
+            ORDER BY G.id
             """
             return await self.db_session.fetch_all(
                 query,

--- a/src/repositories/groups.py
+++ b/src/repositories/groups.py
@@ -97,7 +97,7 @@ class GroupsRepository:
                     "contract_description": group_data.contract_description
                     if group_data.contract_description
                     else "",
-                    "contract_url": group_data.contract_url
+                    "contract_url": str(group_data.contract_url)
                     if group_data.contract_url
                     else "",
                 },

--- a/src/repositories/roles.py
+++ b/src/repositories/roles.py
@@ -20,5 +20,6 @@ class RolesRepository:
             query = """
             SELECT R.id, R.role_name, R.is_admin
             FROM roles AS R
+            ORDER BY R.id
             """
             return await self.db_session.fetch_all(query)

--- a/src/repositories/scopes.py
+++ b/src/repositories/scopes.py
@@ -30,7 +30,6 @@ class ScopesRepository:
         contract_description: str | None = None,
         contract_url: str | None = None,
     ):
-        print(scopes, contract_description, contract_url)
         async with self.db_session.transaction():
             query = """
             UPDATE group_service_provider_relations

--- a/src/repositories/scopes.py
+++ b/src/repositories/scopes.py
@@ -23,12 +23,17 @@ class ScopesRepository:
             )
 
     async def update(
-        self, service_provider_id: int, group_id: int, scopes: str, contract: str
+        self,
+        service_provider_id: int,
+        group_id: int,
+        scopes: str,
+        contract_description: str,
+        contract_url: str,
     ):
         async with self.db_session.transaction():
             query = """
             UPDATE group_service_provider_relations
-            SET scopes = :scopes, contract = :contract
+            SET scopes = :scopes, contract_description = :contract_description, contract_url = :contract_url
             WHERE service_provider_id = :service_provider_id AND group_id = :group_id
             RETURNING *
             """
@@ -38,7 +43,8 @@ class ScopesRepository:
                     "service_provider_id": service_provider_id,
                     "group_id": group_id,
                     "scopes": scopes,
-                    "contract": contract,
+                    "contract_description": contract_description,
+                    "contract_url": contract_url,
                 },
             )
 
@@ -47,7 +53,11 @@ class ScopesRepository:
                 resource_type=LOG_RESOURCE_TYPES.GROUP_SERVICE_PROVIDER_RELATION,
                 db_session=self.db_session,
                 resource_id=response["id"],
-                new_values={"scopes": scopes, "contract": contract},
+                new_values={
+                    "scopes": scopes,
+                    "contract_description": contract_description,
+                    "contract_url": contract_url,
+                },
             )
 
             return response

--- a/src/repositories/service_providers.py
+++ b/src/repositories/service_providers.py
@@ -11,6 +11,7 @@ class ServiceProvidersRepository:
             SELECT SP.id, SP.name, SP.url
             FROM service_providers as SP
             WHERE SP.id = :service_provider_id
+            ORDER BY SP.id
             """
             return await self.db_session.fetch_one(
                 query, {"service_provider_id": service_provider_id}

--- a/src/repositories/service_providers.py
+++ b/src/repositories/service_providers.py
@@ -8,7 +8,7 @@ class ServiceProvidersRepository:
     async def get_by_id(self, service_provider_id: int) -> ServiceProviderResponse:
         async with self.db_session.transaction():
             query = """
-            SELECT SP.id, SP.name
+            SELECT SP.id, SP.name, SP.url
             FROM service_providers as SP
             WHERE SP.id = :service_provider_id
             """

--- a/src/repositories/users.py
+++ b/src/repositories/users.py
@@ -73,6 +73,7 @@ class UsersRepository:
                 INNER JOIN group_user_relations as TUR ON TUR.user_id = U.id
                 INNER JOIN roles as R ON TUR.role_id = R.id
                 WHERE TUR.group_id = :group_id
+                ORDER BY U.id
                 """
             return await self.db_session.fetch_all(query, {"group_id": group_id})
 

--- a/src/routers/groups.py
+++ b/src/routers/groups.py
@@ -22,7 +22,7 @@ async def list_groups(
     group_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Liste les équipes disponibles pour votre fournisseur de services.
+    Liste les groupes disponibles pour votre fournisseur de services.
     """
     return await group_service.list_groups()
 
@@ -35,7 +35,7 @@ async def search(
     group_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Recherche les équipes d’un utilisateur, avec son adresse e-mail et son sub ProConnect.
+    Recherche les groupes d’un utilisateur, avec son adresse e-mail et son sub ProConnect.
 
     Cet appel agit comme une verification (cf route `/users/verify`), et permet de "vérifier" le compte de l’utilisateur.
     """
@@ -51,7 +51,7 @@ async def by_id(
     group_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Récupère une équipe par son ID. Inclut les utilisateurs, leurs rôles et les droits du groupes sur le fournisseur de service.
+    Récupère un groupe par son ID. Inclut les utilisateurs, leurs rôles et les droits du groupes sur le fournisseur de service.
     """
     return await group_service.get_group_with_users_and_scopes(group_id)
 
@@ -71,7 +71,7 @@ async def create(
     groups_service: GroupsService = Depends(get_groups_service),
 ) -> GroupResponse:
     """
-    Crée une nouvelle équipe.
+    Crée un nouveau groupe.
 
     Si l’organisation n’existe pas encore, elle est créée automatiquement.
     """

--- a/src/routers/groups.py
+++ b/src/routers/groups.py
@@ -69,7 +69,7 @@ async def create(
         description="Indique si l'appel est effectué côté serveur. Permet de créer un groupe sans l'intervention d’un utilisateur ProConnecté. Si mis à `True`, `acting_user_sub` n'est pas requis.",
     ),
     groups_service: GroupsService = Depends(get_groups_service),
-):
+) -> GroupResponse:
     """
     Crée une nouvelle équipe.
 

--- a/src/routers/groups_admin.py
+++ b/src/routers/groups_admin.py
@@ -10,7 +10,7 @@ from ..services.groups import GroupsService
 
 router = APIRouter(
     prefix="/groups",
-    tags=["Administration d’une équipe"],
+    tags=["Administration d’un groupe"],
     dependencies=[Depends(decode_access_token)],
     responses={404: {"description": "Not found"}, 400: {"description": "Bad request"}},
 )
@@ -18,7 +18,7 @@ router = APIRouter(
 
 @router.put("/{group_id}", response_model=GroupResponse)
 async def update_name(
-    group_id: int = Path(..., description="ID de l’équipe"),
+    group_id: int = Path(..., description="ID du groupe"),
     group_name: str = Query(..., description="Nouveau nom"),
     acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
@@ -26,7 +26,7 @@ async def update_name(
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Mise à jour du nom d’une équipe.
+    Mise à jour du nom d’un groupe.
     """
     await groups_service.verify_acting_user_rights(acting_user_sub, group_id)
     return await groups_service.update_group(group_id, group_name)
@@ -36,7 +36,7 @@ async def update_name(
 @router.post("/{group_id}/users", status_code=201)
 async def add_user(
     user_in_group: UserInGroupCreate,
-    group_id: int = Path(..., description="ID de l’équipe"),
+    group_id: int = Path(..., description="ID du groupe"),
     acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
     ),
@@ -58,7 +58,7 @@ async def add_user(
 
 @router.patch("/{group_id}/users/{user_id}", status_code=200)
 async def update_user_role(
-    group_id: int = Path(..., description="ID de l’équipe"),
+    group_id: int = Path(..., description="ID du groupe"),
     user_id: int = Path(..., description="ID de l’utilisateur"),
     acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
@@ -67,7 +67,7 @@ async def update_user_role(
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Met à jour le rôle d’un utilisateur dans une équipe
+    Met à jour le rôle d’un utilisateur dans un groupe
 
     Si le groupe, l’utilisateur ou le rôle n’existe pas, une erreur 404 sera levée.
     """
@@ -77,7 +77,7 @@ async def update_user_role(
 
 @router.delete("/{group_id}/users/{user_id}", status_code=204)
 async def remove_user(
-    group_id: int = Path(..., description="ID de l’équipe"),
+    group_id: int = Path(..., description="ID du groupe"),
     user_id: int = Path(..., description="ID de l’utilisateur"),
     acting_user_sub: UUID4 = Query(
         ..., description="Sub ProConnect de l’utilisateur effectuant la requête"
@@ -85,7 +85,7 @@ async def remove_user(
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
-    Retire un utilisateur d’une équipe.
+    Retire un utilisateur d’un groupe.
 
     Si le groupe, ou l’utilisateur, une erreur 404 sera levée.
     """

--- a/src/routers/groups_scopes.py
+++ b/src/routers/groups_scopes.py
@@ -8,7 +8,7 @@ from ..services.groups import GroupsService
 
 router = APIRouter(
     prefix="/groups",
-    tags=["Gestion des droits d’une équipe"],
+    tags=["Gestion des droits d’un groupe"],
     dependencies=[Depends(decode_access_token)],
     responses={404: {"description": "Not found"}, 400: {"description": "Bad request"}},
 )
@@ -23,8 +23,8 @@ async def update_group_scopes(
 ):
     """
     Met à jour :
-    - les droits ou `scopes` d’une équipe sur votre fournisseur de service
-    - le contrat qui lie l’équipe à votre fournisseur de service
+    - les droits ou `scopes` d’un groupe sur votre fournisseur de service
+    - le contrat qui lie le groupe à votre fournisseur de service
     """
     return await groups_service.update_scopes(
         group_id, scopes if scopes else "", contract if contract else ""

--- a/src/routers/groups_scopes.py
+++ b/src/routers/groups_scopes.py
@@ -18,7 +18,8 @@ router = APIRouter(
 async def update_group_scopes(
     group_id: int,
     scopes: str | None = "",
-    contract: str | None = "",
+    contract_description: str | None = "",
+    contract_url: str | None = "",
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
@@ -27,5 +28,8 @@ async def update_group_scopes(
     - le contrat qui lie le groupe à votre fournisseur de service
     """
     return await groups_service.update_scopes(
-        group_id, scopes if scopes else "", contract if contract else ""
+        group_id,
+        scopes if scopes else "",
+        contract_description if contract_description else "",
+        contract_url if contract_url else "",
     )

--- a/src/routers/groups_scopes.py
+++ b/src/routers/groups_scopes.py
@@ -17,9 +17,9 @@ router = APIRouter(
 @router.patch("/{group_id}/scopes", status_code=200)
 async def update_group_scopes(
     group_id: int,
-    scopes: str | None = "",
-    contract_description: str | None = "",
-    contract_url: str | None = "",
+    scopes: str | None = None,
+    contract_description: str | None = None,
+    contract_url: str | None = None,
     groups_service: GroupsService = Depends(get_groups_service),
 ):
     """
@@ -29,7 +29,7 @@ async def update_group_scopes(
     """
     return await groups_service.update_scopes(
         group_id,
-        scopes if scopes else "",
-        contract_description if contract_description else "",
-        contract_url if contract_url else "",
+        scopes,
+        contract_description,
+        contract_url,
     )

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -58,7 +58,7 @@ async def confirm_user(
     user_email: EmailStr,
     user_sub: UUID4,
     users_service: UsersService = Depends(get_users_service),
-) -> None:
+) -> UserResponse:
     """
     Enregistre le sub ProConnect d’un utilisateur et permet de "vérifier" l’utilisateur.
 

--- a/src/routers/users.py
+++ b/src/routers/users.py
@@ -27,7 +27,7 @@ async def create(
 
     Quand l'utilisateur est créé, il est encore non vérifié. Un appel à l'endpoint `/users/verify` permet de le confirmer avec son sub ProConnect.
 
-    Cela permet de créér un utilisateur et de l’ajouter à une équipe sans connaitre son sub.
+    Cela permet de créér un utilisateur et de l’ajouter à un groupe sans connaitre son sub.
     """
     return await users_service.create_user(user)
 

--- a/src/services/admin/write_service.py
+++ b/src/services/admin/write_service.py
@@ -75,10 +75,9 @@ class AdminWriteService:
         return await self.admin_write_repository.set_admin(group_id, user_id)
 
     async def create_service_provider(
-        self,
-        name: str,
+        self, name: str, url: str
     ) -> ServiceProviderResponse:
         """
         Create a new service provider.
         """
-        return await self.admin_write_repository.create_service_provider(name)
+        return await self.admin_write_repository.create_service_provider(name, url)

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -148,7 +148,8 @@ class GroupsService:
         )
 
         group_dict["scopes"] = scopes_and_contract.scopes
-        group_dict["contract"] = scopes_and_contract.contract
+        group_dict["contract_description"] = scopes_and_contract.contract_description
+        group_dict["contract_url"] = scopes_and_contract.contract_url
 
         return GroupWithUsersAndScopesResponse(**group_dict)
 
@@ -229,7 +230,9 @@ class GroupsService:
             group.id, user_id, role.id
         )
 
-    async def update_scopes(self, group_id: int, scopes: str, contract: str):
+    async def update_scopes(
+        self, group_id: int, scopes: str, contract_description: str, contract_url: str
+    ):
         group = await self.get_group_by_id(group_id)
         service_provider = (
             await self.service_provider_service.get_service_provider_by_id(
@@ -241,7 +244,7 @@ class GroupsService:
         await self.scopes_service.get_scopes_and_contract(service_provider.id, group.id)
         # check if the group is linked to the service provider
         return await self.scopes_service.update(
-            service_provider.id, group.id, scopes, contract
+            service_provider.id, group.id, scopes, contract_description, contract_url
         )
 
     def is_user_in_group(

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -187,9 +187,9 @@ class GroupsService:
                 detail=f"User with ID {user.id} is already in group {group_id}",
             )
 
-        return await self.groups_repository.add_user_to_group(
-            group.id, user.id, role.id
-        )
+        await self.groups_repository.add_user_to_group(group.id, user.id, role.id)
+
+        return user
 
     async def remove_user_from_group(self, group_id: int, user_id: int):
         user = await self.users_service.get_user_by_id(

--- a/src/services/groups.py
+++ b/src/services/groups.py
@@ -231,7 +231,11 @@ class GroupsService:
         )
 
     async def update_scopes(
-        self, group_id: int, scopes: str, contract_description: str, contract_url: str
+        self,
+        group_id: int,
+        scopes: str | None = None,
+        contract_description: str | None = None,
+        contract_url: str | None = None,
     ):
         group = await self.get_group_by_id(group_id)
         service_provider = (

--- a/src/services/scopes.py
+++ b/src/services/scopes.py
@@ -33,9 +33,9 @@ class ScopesService:
         self,
         service_provider_id: int,
         group_id: int,
-        scopes: str,
-        contract_description: str,
-        contract_url: str,
+        scopes: str | None = None,
+        contract_description: str | None = None,
+        contract_url: str | None = None,
     ) -> None:
         existing_scopes = await self.scopes_repository.get(
             service_provider_id, group_id

--- a/src/services/scopes.py
+++ b/src/services/scopes.py
@@ -21,11 +21,21 @@ class ScopesService:
 
         return ScopeBase(
             scopes=(scopes_response.scopes or "") if scopes_response else "",
-            contract=(scopes_response.contract or "") if scopes_response else "",
+            contract_description=(scopes_response.contract_description or "")
+            if scopes_response
+            else "",
+            contract_url=(scopes_response.contract_url or None)
+            if scopes_response
+            else None,
         )
 
     async def update(
-        self, service_provider_id: int, group_id: int, scopes: str, contract: str
+        self,
+        service_provider_id: int,
+        group_id: int,
+        scopes: str,
+        contract_description: str,
+        contract_url: str,
     ) -> None:
         existing_scopes = await self.scopes_repository.get(
             service_provider_id, group_id
@@ -37,5 +47,5 @@ class ScopesService:
             )
 
         return await self.scopes_repository.update(
-            service_provider_id, group_id, scopes, contract
+            service_provider_id, group_id, scopes, contract_description, contract_url
         )

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -28,6 +28,8 @@ class UsersService:
         else:
             await self.user_repository.mark_user_as_verified(user_email, user_sub)
 
+        return await self.get_user_by_email(user_email, only_verified_user=True)
+
     async def get_user_by_email(
         self, email: str, only_verified_user: boolean = True
     ) -> UserResponse:

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -12,7 +12,8 @@ def random_group():
         "organisation_siret": DINUM_SIRET,
         "admin": {"email": f"admin_{random.randint(1000, 9999)}@example.com"},
         "scopes": "read maintain",
-        "contract": "datapass_test",
+        "contract_description": "datapass_test",
+        "contract_url": "https://example.com/contract",
         "members": [{"email": f"member_{random.randint(1000, 9999)}@example.com"}],
     }
 

--- a/src/tests/integration/test_3_users.py
+++ b/src/tests/integration/test_3_users.py
@@ -77,3 +77,4 @@ def test_uuid_format(client):
     )
 
     assert response_verify_ok.status_code == 200
+    assert response_verify_ok.json()["is_verified"] is not False

--- a/src/tests/integration/test_4_groups.py
+++ b/src/tests/integration/test_4_groups.py
@@ -48,7 +48,8 @@ def test_create_group(client):
     assert group["name"] == new_group["name"]
     assert group["organisation_siret"] == new_group["organisation_siret"]
     assert group["scopes"] == new_group["scopes"]
-    assert group["contract"] == new_group["contract"]
+    assert group["contract_description"] == new_group["contract_description"]
+    assert group["contract_url"] == new_group["contract_url"]
 
     assert any(
         user for user in group["users"] if user["email"] == new_group["admin"]["email"]
@@ -124,7 +125,8 @@ def test_search_group_by_user(client):
     assert group[0]["name"] == new_group_data["name"]
     assert group[0]["organisation_siret"] == new_group_data["organisation_siret"]
     assert group[0]["scopes"] == new_group_data["scopes"]
-    assert group[0]["contract"] == new_group_data["contract"]
+    assert group[0]["contract_description"] == new_group_data["contract_description"]
+    assert group[0]["contract_url"] == new_group_data["contract_url"]
 
     assert any(
         (

--- a/src/tests/integration/test_4_groups.py
+++ b/src/tests/integration/test_4_groups.py
@@ -186,7 +186,25 @@ def test_get_group_verify_conflict(client):
             "user_sub": initial_sub,
         },
     )
-    # Verify user with a different sub should return 406
+    assert response.status_code == 200
+
+
+def test_get_group_email_with_plus(client):
+    new_group_data = random_group()
+    user = random_user()
+    user_email = "test+" + user["email"]
+
+    new_group_data["admin"]["email"] = user_email
+    response = client.post("/groups/?no_acting_user=True", json=new_group_data)
+    assert response.status_code == 201
+
+    response = client.get(
+        "/groups/search",
+        params={
+            "user_email": new_group_data["admin"]["email"],
+            "user_sub": random_sub_pro_connect(),
+        },
+    )
     assert response.status_code == 200
 
 

--- a/src/tests/integration/test_5_groups_scopes.py
+++ b/src/tests/integration/test_5_groups_scopes.py
@@ -19,3 +19,15 @@ def test_update_scopes(client):
     group = response.json()
     assert group["scopes"] == new_scopes
     assert group["contract_description"] == new_contract
+
+    new_contract_url = "https://example.com/contract"
+    response = client.patch(
+        f"/groups/{new_group_data["id"]}/scopes?scopes={new_scopes}&contract_url={new_contract_url}"
+    )
+    assert response.status_code == 200
+
+    # Verify access was updated
+    response = client.get(f"/groups/{new_group_data["id"]}")
+    assert response.status_code == 200
+    group = response.json()
+    assert group["contract_url"] == new_contract_url

--- a/src/tests/integration/test_5_groups_scopes.py
+++ b/src/tests/integration/test_5_groups_scopes.py
@@ -9,7 +9,7 @@ def test_update_scopes(client):
     new_scopes = "read,write,delete"
     new_contract = "datapass_48"
     response = client.patch(
-        f"/groups/{new_group_data["id"]}/scopes?scopes={new_scopes}&contract={new_contract}"
+        f"/groups/{new_group_data["id"]}/scopes?scopes={new_scopes}&contract_description={new_contract}"
     )
     assert response.status_code == 200
 
@@ -18,4 +18,4 @@ def test_update_scopes(client):
     assert response.status_code == 200
     group = response.json()
     assert group["scopes"] == new_scopes
-    assert group["contract"] == new_contract
+    assert group["contract_description"] == new_contract

--- a/src/tests/integration/test_6_groups_admin.py
+++ b/src/tests/integration/test_6_groups_admin.py
@@ -151,7 +151,7 @@ def test_remove_user_from_group(client):
 
     verify_user(client, admin_email, admin_sub)
 
-    # Add user to group
+    # change user role
     client.patch(
         f"/groups/{new_group_data['id']}/users/{user_id}?acting_user_sub={admin_sub}&role_id={role_id}"
     )

--- a/templates/pages/group.html
+++ b/templates/pages/group.html
@@ -45,8 +45,8 @@
     <td>{{ scope.created_at.strftime('%d/%m/%Y') }}</td>
     <td>{{ scope.updated_at.strftime('%d/%m/%Y') }} {{ scope.updated_at.strftime('%H:%M:%S') }}</td>
     <td>{{scope.service_provider_name}} ({{ scope.service_provider_id }})</td>
-    <td>{{scope.description}}</td>
-    <td>{{scope.contract}}</td>
+    <td>{{scope.contract_description}}</td>
+    <td>{{scope.contract_url}}</td>
     <td>
       {% if scopes_list %}
         {% for s in scopes_list %}

--- a/templates/pages/group.html
+++ b/templates/pages/group.html
@@ -38,19 +38,22 @@
 </tr>
 {% endmacro %}
 
-{% set scopes_headers = ['Creation', 'MAJ', 'Service', 'Scopes'] %}
+{% set scopes_headers = ['Creation', 'MAJ', 'Service', 'Description', 'Contrat', 'Scopes'] %}
 {% macro scope_formatter(scope) %}
 {% set scopes_list = scope.scopes.split(' ') %}
 <tr>
     <td>{{ scope.created_at.strftime('%d/%m/%Y') }}</td>
     <td>{{ scope.updated_at.strftime('%d/%m/%Y') }} {{ scope.updated_at.strftime('%H:%M:%S') }}</td>
     <td>{{scope.service_provider_name}} ({{ scope.service_provider_id }})</td>
+    <td>{{scope.description}}</td>
+    <td>{{scope.contract}}</td>
     <td>
       {% if scopes_list %}
         {% for s in scopes_list %}
             <span class="fr-badge fr-badge--sm">
                 {{ s }}
             </span>
+            <br/>
         {% endfor %}
       {% else %}
           <i>Aucune valeur</i>

--- a/templates/pages/service_create_form.html
+++ b/templates/pages/service_create_form.html
@@ -8,23 +8,25 @@
 
                   <!-- Form field with proper DSFR structure -->
                   <div class="fr-form-group">
-                      <label for="name" class="fr-label">
-                          {{ label}}
+                    {% for field in fields %}
+                      <label for="{{ field.id }}" class="fr-label">
+                          {{ field.label }}
                           <span class="fr-hint-text">
                               {{ label_hint }}
                           </span>
                       </label>
                       <input type="text"
                               autocomplete="off"
-                              id="name"
-                              name="name"
+                              id="{{ field.name }}"
+                              name="{{ field.name }}"
                               class="fr-input"
-                              placeholder="Ex: Mon Service API"
+                              placeholder="{{ field.placeholder }}"
                               required
-                              aria-describedby="name-messages">
-                      <div class="fr-messages-group" id="name-messages" aria-live="assertive">
+                              aria-describedby="{{ field.name }}-messages">
+                      <div class="fr-messages-group" id="{{ field.name }}-messages" aria-live="assertive">
                           <!-- Error messages will appear here -->
                       </div>
+                    {% endfor %}
                   </div>
 
                   <br/>

--- a/templates/pages/service_providers.html
+++ b/templates/pages/service_providers.html
@@ -9,9 +9,10 @@
         <td>{{ sp.updated_at.strftime('%d/%m/%Y') }} {{ sp.updated_at.strftime('%H:%M:%S') }}</td>
         <td>{{sp.id}}</td>
         <td><a href='/admin/service-providers/{{sp.id}}'>{{ sp.name }}</a></td>
+        <td><a href='{{ sp.url }}'>{{ sp.url }}</a></td>
     </tr>
 {% endmacro %}
-{% set headers = ['Creation', 'MAJ', 'ID', 'Nom'] %}
+{% set headers = ['Creation', 'MAJ', 'ID', 'Nom', 'Url'] %}
 
 <div class="fr-container">
     <div class="fr-grid-row fr-grid-row--right">


### PR DESCRIPTION
- returns ID when adding a user to a group
- create a description column next to contract and scopes
- create an url column for service provider
- prefer `groupes` over  `équipes`