### PR TITLE
fix(resource-server): fixes uppercased email on resource server check

### DIFF
--- a/src/repositories/users_sub.py
+++ b/src/repositories/users_sub.py
@@ -33,7 +33,7 @@ class UserSubsRepository:
             query = """
             SELECT coalesce(U.sub_pro_connect, '') as sub FROM users as U WHERE U.email = :email
             """
-            record = await self.db_session.fetch_one(query, {"email": email})
+            record = await self.db_session.fetch_one(query, {"email": email.lower()})
             return record["sub"] if record else None
 
     async def set(self, email: str, sub: UUID) -> None:


### PR DESCRIPTION
Email is lowered almost everywhere except in here. This could cause a user to be rejected (without any groups) because the email query won't return any valid user